### PR TITLE
feat(committee): adopt discussion→voting→consensus flow with unanimit…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,107 @@
+# Server & CORS
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS="http://localhost:3000,http://localhost:5173"
+
+# Node environment: development | production | test
+NODE_ENV="development"
+
+# Logging level: error | warn | info | http | verbose | debug | silly
+LOG_LEVEL="info"
+
+
+# JWT (Auth)
+# Strong secrets (≥ 32 chars recommended) and token lifetimes
+JWT_ACCESS_SECRET="change-me-access-secret-32chars-minimum"
+JWT_REFRESH_SECRET="change-me-refresh-secret-32chars-minimum"
+JWT_ACCESS_EXPIRY="15m"
+JWT_REFRESH_EXPIRY="7d"
+
+
+# Encryption & Private Key
+# Symmetric key used to encrypt/decrypt the oracle private key (≥ 32 chars)
+ENCRYPTION_KEY="please-generate-a-32-char-secure-key"
+
+# Encrypted private key used by the oracle wallet (produced by `npm run encrypt-key`)
+ORACLE_PRIVATE_KEY_ENCRYPTED="<paste-output-of-encrypt-key>"
+
+# NEVER store plaintext private keys in production; only for quick local dev:
+# ORACLE_PRIVATE_KEY="0x..."
+
+
+# Blockchain
+# Ethereum RPC endpoint (HTTP). Set to your testnet/mainnet RPC URL.
+ETHEREUM_RPC_URL="http://localhost:8545"
+
+# Address of the deployed main/oracle contract
+MAIN_CONTRACT_ADDRESS="0x0000000000000000000000000000000000000000"
+
+# Toggle blockchain behavior in managed environments
+BLOCKCHAIN_MOCK_MODE="false"         # true = simulate on-chain ops (no real transactions)
+USE_REAL_BLOCKCHAIN="false"          # true = allow real chain usage (e.g., on Railway)
+
+# Optional ABI overrides (either inline JSON or a path to a JSON file)
+# MAIN_CONTRACT_ABI_JSON='[ ... ]'
+# MAIN_CONTRACT_ABI_PATH="./abi/ABBetting.json"
+
+# Polling intervals (ms)
+ETHEREUM_POLLING_INTERVAL="10000"    # interval to poll for events
+FILTER_REFRESH_INTERVAL="240000"     # interval to refresh filters (4 min)
+
+
+# Committee (MoA) Configuration
+# Enable committee mode by default (otherwise single AI mode)
+USE_COMMITTEE="true"
+
+# Discussion/voting flow controls
+UNANIMOUS_MAX_ROUNDS="10"            # max voting rounds to attempt unanimity
+DISCUSSION_ROUNDS="2"                # per round, peer-aware stance updates per agent
+
+# Consensus method label for visualization/metadata
+COMMITTEE_CONSENSUS_METHOD="weighted_voting"  # majority | borda | weighted_voting
+
+# Judging weights (used by some ranking/synthesis paths)
+JUDGE_RULE_BASED_WEIGHT="0.4"
+JUDGE_LLM_WEIGHT="0.6"
+JUDGE_PAIRWISE_ROUNDS="3"
+
+# Proposer toggles (created only if API keys exist and not explicitly disabled)
+PROPOSER_GPT5_ENABLED="true"
+PROPOSER_CLAUDE_ENABLED="true"
+PROPOSER_GEMINI_ENABLED="true"
+
+# Alternatively, override enabled proposer list inside the orchestrator
+# COMMITTEE_ENABLED_PROPOSERS="gpt4,claude,gemini"
+
+
+# AI Providers
+# OpenAI
+OPENAI_API_KEY="sk-..."
+OPENAI_MODEL="gpt-5-2025-08-07"
+OPENAI_FALLBACK_TO_MOCK="false"      # true = return mock outputs when API key is absent
+
+# Anthropic (Claude)
+ANTHROPIC_API_KEY="sk-ant-..."
+ANTHROPIC_MODEL="claude-sonnet-4-20250514"
+
+# Google (Gemini)
+GOOGLE_API_KEY="AIza..."
+GOOGLE_MODEL="gemini-2.5-pro"
+
+
+# Database (optional)
+# Enable persistent storage with MongoDB
+USE_MONGODB="false"
+MONGODB_URI="mongodb://localhost:27017"
+MONGODB_DB_NAME="agora_oracle"
+
+
+# Monitoring / Misc
+# Interval for internal monitors (ms)
+MONITORING_INTERVAL="10000"
+
+# Public keys for frontends (only if shared build is used)
+NEXT_PUBLIC_AGREEMENT_FACTORY_ADDRESS="0x0000000000000000000000000000000000000000"
+NEXT_PUBLIC_ONCHAINKIT_API_KEY="public-demo-key"
+
+# Backend secret for OnchainKit integration (if used)
+ONCHAINKIT_API_KEY_SECRET="server-side-secret"

--- a/README.md
+++ b/README.md
@@ -1,298 +1,146 @@
-# Agora Backend - AI Oracle for Ethereum dApp
+# Agora Backend — AI Oracle for Ethereum dApp
 
-이더리움 메인넷 dApp을 위한 AI 오라클 백엔드 서비스입니다. Clean Architecture와 DIP(의존성 역전 원칙)를 적용한 모듈화된 구조로 설계되었습니다.
+Clean, modular backend for an Ethereum dApp with an AI oracle that can determine winners either via a single AI or via a committee of agents (Mixture‑of‑Agents). The architecture follows Clean Architecture and the Dependency Inversion Principle (DIP).
 
-## 🔒 보안 기능
+## Security
 
-- **JWT 기반 인증/인가**: Access Token과 Refresh Token을 사용한 안전한 인증
-- **입력 검증**: Joi를 사용한 모든 API 엔드포인트의 입력 데이터 검증
-- **Private Key 암호화**: AES 암호화를 통한 안전한 키 관리
-- **Rate Limiting**: DDoS 공격 방지를 위한 요청 제한
-- **보안 헤더**: Helmet을 통한 HTTP 보안 헤더 설정
-- **CORS 설정**: 허용된 도메인만 접근 가능
+- JWT authentication/authorization with access and refresh tokens
+- Input validation for every endpoint (Joi)
+- Encrypted private key management (AES)
+- Global and per‑route rate limiting
+- Secure HTTP headers (Helmet)
+- CORS whitelist
 
-## 주요 기능
+## Features
 
-- 스마트 컨트랙트의 베팅 종료 시점 모니터링
-- **위원회 기반 AI 결정 시스템**: MoA(Mixture-of-Agents) + LLM-as-Judge 아키텍처
-  - 다중 AI 에이전트의 협의 및 토론을 통한 승자 결정
-  - GPT-5, Claude, Gemini 등 다양한 AI 모델 활용
-  - 규칙 기반 + LLM 기반 심사 시스템
-  - 가중 투표, 보르다 카운트, 다수결 등 다양한 합의 메커니즘
-- 블록체인에 승자 정보 제출 (상세한 위원회 결정 증명 포함)
-- RESTful API 제공
-- 실시간 로깅 및 모니터링
-- Graceful Shutdown 지원
+- Contract monitoring and on‑chain winner declaration
+- Committee‑based AI decision system (MoA with discussion + voting)
+  - Multiple AI agents propose and iteratively refine positions via peer‑aware discussion
+  - Unanimity‑first consensus; if not reached within a cap, fallback to simple majority
+  - GPT‑5, Claude, Gemini proposers (toggleable)
+  - Rich deliberation visualization (SSE stream, messages, metrics)
+- On‑chain winner submission (with committee metadata/proof)
+- RESTful APIs, structured logs, graceful shutdown
 
-## 아키텍처
-
-### Clean Architecture 레이어
+## Architecture
 
 ```
 src/
-├── domain/           # 엔티티, 비즈니스 규칙, 인터페이스 정의
-│   ├── entities/     # Contract, Party, OracleDecision, CommitteeDecision, AgentProposal
-│   ├── repositories/ # 레포지토리 인터페이스
-│   ├── services/     # ICommitteeService, IAgentService, IAIService 등
-│   └── valueObjects/ # ConsensusResult, ProposalMetadata
-├── application/      # 유스케이스, 비즈니스 로직
-│   └── useCases/     # DecideWinnerUseCase (단일 AI + 위원회 모드), MonitorContractsUseCase
-├── infrastructure/   # 외부 시스템 구현체
-│   ├── committee/   # 위원회 시스템
-│   │   ├── CommitteeOrchestrator.ts      # 전체 오케스트레이션
-│   │   ├── proposers/                    # AI 에이전트들
-│   │   │   ├── GPT5Proposer.ts
-│   │   │   ├── ClaudeProposer.ts
-│   │   │   └── GeminiProposer.ts
-│   │   ├── judges/                       # 심사 시스템
-│   │   │   ├── RuleBasedJudge.ts         # 규칙 기반 심사
-│   │   │   ├── LLMJudge.ts              # LLM 기반 심사
-│   │   │   └── CommitteeJudgeService.ts  # 통합 심사 서비스
-│   │   └── synthesizer/                  # 합의 생성
-│   │       └── ConsensusSynthesizer.ts
-│   ├── ai/          # 기존 단일 AI 서비스
-│   ├── blockchain/  # 이더리움 통신
-│   └── repositories/# 레포지토리 구현
-└── interfaces/       # 외부 인터페이스
-    ├── controllers/  # HTTP 컨트롤러
-    └── routes/      # Express 라우트
+├── domain/                # Entities, domain services and value objects
+│   ├── entities/          # Contract, Party, OracleDecision, CommitteeDecision, AgentProposal
+│   ├── repositories/      # Repository interfaces
+│   ├── services/          # ICommitteeService, IAgentService, IAIService, etc.
+│   └── valueObjects/      # ConsensusResult, DeliberationVisualization, DeliberationMessage
+├── application/           # Use cases
+│   └── useCases/          # DecideWinnerUseCase, MonitorContractsUseCase
+├── infrastructure/        # External implementations
+│   ├── committee/         # Committee orchestration
+│   │   ├── CommitteeOrchestrator.ts
+│   │   ├── proposers/     # GPT5Proposer, ClaudeProposer, GeminiProposer
+│   │   ├── judges/        # RuleBasedJudge, LLMJudge, CommitteeJudgeService
+│   │   └── synthesizer/   # ConsensusSynthesizer (for legacy/alt methods)
+│   ├── ai/                # Single‑AI service
+│   ├── blockchain/        # Ethereum integration
+│   └── repositories/      # In‑memory and MongoDB repositories
+└── interfaces/            # HTTP interfaces
+    ├── controllers/
+    └── routes/
 ```
 
-## 설치 및 실행
+## Setup
 
-### 필수 요구사항
+### Requirements
 
-- Node.js v16 이상
-- npm 또는 yarn
-- Ethereum RPC 엔드포인트
-- OpenAI API 키 (또는 다른 AI 서비스)
+- Node.js ≥ 16
+- npm or yarn
+- Ethereum RPC endpoint
+- AI API keys (OpenAI, Anthropic, Google) as needed
 
-### 설치
+### Install
 
-```bash
+```
 npm install
 ```
 
-### 환경 설정
+### Configure
 
-`.env.example`을 복사하여 `.env` 파일을 생성하고 필요한 값을 설정:
+Create a `.env` from the example and fill values:
 
-```bash
+```
 cp .env.example .env
 ```
 
-### Private Key 암호화
+Optionally encrypt your Ethereum private key:
 
-보안을 위해 이더리움 Private Key는 암호화하여 저장해야 합니다:
-
-```bash
+```
 npm run encrypt-key
 ```
 
-위 명령을 실행하면 Private Key와 암호화 키를 입력받아 암호화된 키를 생성합니다.
-생성된 암호화 키를 `.env` 파일의 `ORACLE_PRIVATE_KEY_ENCRYPTED`에 설정하세요.
+Set the resulting encrypted value to `ORACLE_PRIVATE_KEY_ENCRYPTED` in `.env`.
 
-### 개발 모드 실행
+### Run
 
-```bash
+Development:
+
+```
 npm run dev
 ```
 
-### 프로덕션 빌드 및 실행
+Production:
 
-```bash
+```
 npm run build
 npm start
 ```
 
-## API 엔드포인트
+## Environment Variables
 
-### 인증 엔드포인트
+Core toggles:
 
-#### 로그인
-```
-POST /api/auth/login
-Content-Type: application/json
+- `USE_COMMITTEE=true` — enable committee mode by default
+- `COMMITTEE_CONSENSUS_METHOD=weighted_voting|majority|borda` — synthesis method (visualization metadata)
+- `PROPOSER_GPT5_ENABLED=true|false`, `PROPOSER_CLAUDE_ENABLED=true|false`, `PROPOSER_GEMINI_ENABLED=true|false`
+- `UNANIMOUS_MAX_ROUNDS=10` — max voting rounds to try for unanimity before majority fallback
+- `DISCUSSION_ROUNDS=2` — per round, how many peer‑aware stance updates each agent performs
 
-{
-  "username": "string",
-  "password": "string"
-}
-```
+AI keys:
 
-#### 토큰 갱신
-```
-POST /api/auth/refresh
-Content-Type: application/json
+- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`
 
-{
-  "refreshToken": "string"
-}
-```
+Blockchain:
 
-### 오라클 엔드포인트
+- `ETHEREUM_RPC_URL`, `MAIN_CONTRACT_ADDRESS` (or `ORACLE_CONTRACT_ADDRESS`)
+- `BLOCKCHAIN_MOCK_MODE=true|false` — mock submissions/listeners
+- `USE_REAL_BLOCKCHAIN=true|false` — allow real chain in managed environments
 
-#### 헬스 체크
+MongoDB (optional):
+
+- `USE_MONGODB=true` and a valid `MONGODB_URI`
+
+## API
+
+Base: the app mounts routes under `/api/auth`, `/api/oracle`, and `/api/deliberations`.
+
+### Health
+
 ```
 GET /health
 ```
 
-#### 승자 결정 요청 (인증 필요)
+### Auth
+
+```
+POST /api/auth/login
+POST /api/auth/refresh
+```
+
+### Oracle
+
+- Decide winner (auth: ADMIN or ORACLE_NODE):
+
 ```
 POST /api/oracle/contracts/:contractId/decide-winner
-Authorization: Bearer <access_token>
-```
-- 권한: ADMIN 또는 ORACLE_NODE
-- Rate Limit: 분당 10회
-
-#### 결정 결과 조회 (인증 필요)
-```
-GET /api/oracle/contracts/:contractId/decision
-Authorization: Bearer <access_token>
-```
-
-## 테스트
-
-```bash
-npm test
-```
-
-## 스크립트
-
-- `npm run build`: TypeScript 컴파일
-- `npm run dev`: 개발 서버 실행
-- `npm start`: 프로덕션 서버 실행
-- `npm test`: 테스트 실행
-- `npm run lint`: ESLint 실행
-- `npm run typecheck`: TypeScript 타입 체크
-- `npm run encrypt-key`: Private Key 암호화 도구
-
-## 확장 가능성
-
-이 프로젝트는 다음과 같은 확장이 가능하도록 설계되었습니다:
-
-1. **다른 AI 서비스 통합**: `IAIService` 인터페이스 구현
-2. **다른 블록체인 지원**: `IBlockchainService` 인터페이스 구현
-3. **영구 저장소 추가**: `IContractRepository`, `IOracleDecisionRepository` 구현
-4. **추가 비즈니스 로직**: 새로운 Use Case 추가
-
-## 🛡️ 개선된 보안 및 안정성
-
-### 보안 개선사항
-- JWT 기반 인증/인가 시스템
-- 모든 입력에 대한 Joi 검증
-- Private Key AES 암호화
-- Rate Limiting (API, 인증, 오라클별 설정)
-- Helmet을 통한 보안 헤더
-- CORS 화이트리스트
-
-### 안정성 개선사항
-- Winston 로깅 시스템
-- 글로벌 에러 핸들링
-- Graceful Shutdown
-- 이벤트 리스너 메모리 누수 방지
-- Mutex를 통한 Race Condition 방지
-- MongoDB 지원 (선택적)
-
-### 성능 개선사항
-- OpenAI 실제 구현 (GPT-4 지원)
-- MongoDB 영구 저장소 옵션
-- 비동기 에러 핸들링
-- 요청별 상세 로깅
-
-## ⚠️ 프로덕션 배포 시 주의사항
-
-1. **환경 변수**: 모든 시크릿 키는 안전하게 관리하세요
-2. **Private Key**: 반드시 암호화하여 저장하세요
-3. **JWT Secret**: 최소 32자 이상의 강력한 키 사용
-4. **MongoDB**: 프로덕션에서는 `USE_MONGODB=true` 설정 권장
-5. **Rate Limiting**: 서비스 특성에 맞게 조정
-6. **로그 관리**: 로그 파일 크기 및 로테이션 설정 확인
-
-## 🤖 위원회 기반 AI 결정 시스템 (MoA + LLM-as-Judge)
-
-### 시스템 개요
-
-본 시스템은 **MoA(Mixture-of-Agents)**와 **LLM-as-Judge** 기법을 결합하여 단일 AI의 한계를 극복하고, 다중 AI 에이전트의 협의와 심사를 통해 더 정확하고 신뢰할 수 있는 결정을 내리는 위원회 기반 오라클 시스템입니다.
-
-### 아키텍처 구조
-
-```
-┌─────────────── 1층: 제안자(Proposers) ───────────────┐
-│  GPT-4        Claude        Gemini    (다양한 관점/샘플링) │
-│   └─제안 N개  └─제안 N개    └─제안 N개                 │
-└──────────────────────────────────────────────────────┘
-                    │ (모든 후보 제안)
-                    ▼
-┌─────────────── 2층: 심사단(Judges) ─────────────────┐
-│ 규칙기반 점수(구조/일관성)  +  LLM 쌍대비교(품질평가)    │
-│  ↳ 바이어스 완화: 순서랜덤/길이정규화/근거필수         │
-└──────────────────────────────────────────────────────┘
-                    │ (랭킹/점수, 신뢰도)
-                    ▼
-┌─────────────── 3층: 합의/합성(Synthesizer) ──────────┐
-│  다수결·보르다·가중투표(신뢰가중) → 최종 답안 + 근거    │
-└──────────────────────────────────────────────────────┘
-```
-
-### 핵심 구성 요소
-
-#### 1. **Proposer Layer (제안자 층)**
-- **GPT-4 Proposer**: 체계적 분석과 논리적 추론에 강점
-- **Claude Proposer**: 윤리적 고려사항과 균형잡힌 판단에 중점  
-- **Gemini Proposer**: 다각도 분석과 패턴 인식에 특화
-- **다양성 주입**: 각기 다른 temperature, 프롬프트 관점, 샘플링 방식 적용
-
-#### 2. **Judge Layer (심사 층)**
-- **Rule-Based Judge**: 구조적 품질 평가
-  - 완전성(제안의 충실도)
-  - 일관성(논리적 모순 검출)
-  - 증거 품질(근거의 신뢰성)
-  - 명확성(표현의 정확성)
-- **LLM Judge**: 지능적 품질 평가  
-  - 쌍대 비교를 통한 상대적 우수성 판단
-  - 바이어스 완화 기법 적용 (순서 무작위화, 길이 정규화)
-  - 다중 라운드 심사로 일관성 확보
-
-#### 3. **Synthesizer Layer (합의 층)**
-- **합의 방법론**:
-  - `majority`: 단순 다수결
-  - `borda`: 순위 기반 점수 집계
-  - `weighted_voting`: 에이전트별 성능 가중치 적용  
-  - `approval`: 임계값 기반 승인 투표
-- **증거 통합**: 승리 제안들의 증거를 관련성/신뢰성 기준으로 병합
-- **불확실성 추적**: 잔여 불확실성과 품질 플래그 생성
-
-### 사용 방법
-
-#### 환경 설정
-
-```bash
-# 위원회 시스템 활성화
-USE_COMMITTEE=true
-
-# 에이전트 설정
-COMMITTEE_CONSENSUS_METHOD=weighted_voting
-COMMITTEE_MIN_AGENTS=3
-COMMITTEE_MAX_PROPOSALS_PER_AGENT=2
-
-# AI 서비스 설정 (실제 API 키 필요)
-OPENAI_API_KEY=your_actual_openai_key
-CLAUDE_API_KEY=your_claude_key  
-GOOGLE_AI_API_KEY=your_gemini_key
-
-# 테스트용 (Mock 응답 사용)
-OPENAI_FALLBACK_TO_MOCK=true
-CLAUDE_API_KEY=mock
-GOOGLE_AI_API_KEY=mock
-```
-
-#### API 사용 예시
-
-```bash
-# 위원회 모드로 결정 요청
-POST /api/oracle/contracts/contract_123/decide-winner
-Authorization: Bearer <access_token>
+Authorization: Bearer <token>
 Content-Type: application/json
 
 {
@@ -306,75 +154,101 @@ Content-Type: application/json
 }
 ```
 
-#### 응답 예시
+- Start async deliberation (auth):
 
-```json
+```
+POST /api/oracle/contracts/:contractId/start-deliberation
+```
+
+Returns `{ deliberationId }` immediately; consume SSE at `/api/deliberations/:deliberationId/stream`.
+
+- Public winner arguments by contract:
+
+```
+GET /api/oracle/contracts/:contractId/winner-arguments?lang=en|ko
+```
+
+Builds three jury arguments and a conclusion supporting the chosen winner (uses Claude if available; otherwise a local fallback).
+
+- Public: idempotent “ended” notifier (closes betting on‑chain when appropriate):
+
+```
+POST /api/oracle/contracts/:contractId/ended
+Content-Type: application/json
+
 {
-  "success": true,
-  "winnerId": "partyA",
-  "decisionId": "decision_1692819234567_abc123",
-  "deliberationMode": "committee",
-  "transactionHash": "0x...",
-  "committeeMetrics": {
-    "totalProposals": 6,
-    "deliberationTimeMs": 8450,
-    "consensusLevel": 0.83,
-    "costBreakdown": {
-      "proposerTokens": 3420,
-      "judgeTokens": 1890,
-      "synthesizerTokens": 760,
-      "totalCostUSD": 0.12
-    }
-  },
-  "committeeDecisionId": "committee_contract_123_1692819234567"
+  "contractId": 31,
+  "endedAt": "2025-09-02T23:16:00.000Z",
+  "bettingEndTime": 1756822571,
+  "chainId": 11155111
 }
 ```
 
-### 주요 특징
+### Deliberations
 
-#### ✅ **바이어스 완화**
-- 순서 무작위화로 위치 편향 제거
-- 길이 정규화로 장황함 편향 완화  
-- 에이전트 이름 마스킹으로 브랜드 편향 방지
-- 다중 라운드 심사로 일관성 검증
+- Get full visualization (auth):
 
-#### 📊 **투명한 의사결정**
-- 각 에이전트의 제안과 근거 추적
-- 심사 과정의 상세 로깅
-- 합의 과정의 메트릭 제공
-- 대안 선택지와 확률 명시
+```
+GET /api/deliberations/:id
+```
 
-#### 🔧 **유연한 설정**
-- 합의 방법론 선택 가능
-- 에이전트별 활성화/비활성화
-- 성능 기반 가중치 자동 조정
-- Early exit으로 효율성 최적화
+- Real‑time SSE stream (no auth; the `:id` acts as a token):
 
-#### 🛡️ **품질 보장**  
-- 규칙 기반 + LLM 기반 이중 검증
-- 신뢰도 추적 및 불확실성 계산
-- 인간 검토 권장 플래그
-- 소수 의견 및 충돌 증거 감지
+```
+GET /api/deliberations/:id/stream
+```
 
-### 성능 및 비용
+- Paginated messages (auth):
 
-- **평균 응답 시간**: 5-15초 (에이전트 수와 제안 수에 따라)
-- **토큰 사용량**: 단일 AI 대비 3-5배 (더 높은 품질 대가)
-- **비용 효율성**: 중요한 결정에서 오류 비용 고려시 ROI 양수
-- **확장성**: 에이전트 추가/제거로 유연한 확장
+```
+GET /api/deliberations/:id/messages?phase=proposing|discussion|consensus|completed&agentId=...
+```
 
-### 단일 AI vs 위원회 모드 비교
+- Winner arguments by deliberation (auth):
 
-| 구분 | 단일 AI 모드 | 위원회 모드 |
-|------|-------------|-------------|
-| 응답 시간 | 1-3초 | 5-15초 |
-| 토큰 비용 | 기준 | 3-5배 |
-| 결정 품질 | 보통 | 높음 |
-| 신뢰도 | 중간 | 높음 |
-| 투명성 | 낮음 | 높음 |
-| 편향 위험 | 높음 | 낮음 |
-| 추천 용도 | 일반적 결정 | 중요한 결정 |
+```
+GET /api/deliberations/:id/winner-arguments
+```
 
-## 라이선스
+- Export report (auth):
+
+```
+GET /api/deliberations/:id/export?format=json|csv
+```
+
+## Committee Flow (Discussion → Voting → Consensus)
+
+- Proposing: agents generate initial proposals for Party A or B with rationales and evidence
+- Discussion rounds: each round, every agent updates a single “anchor” proposal using peer summaries (`DISCUSSION_ROUNDS`)
+- Voting per round: the latest winner from each agent is cast; if all choices are the same, unanimity is achieved and deliberation stops
+- Consensus: if unanimity isn’t reached after `UNANIMOUS_MAX_ROUNDS`, select the majority winner; evidence is merged from supporting proposals
+- Visualization: messages, votes, synthesis and metrics are streamed over SSE and available via the visualization endpoints
+
+## Testing
+
+```
+npm test
+```
+
+## Scripts
+
+- `npm run build` — TypeScript build
+- `npm run dev` — dev server
+- `npm start` — production start
+- `npm test` — run tests
+- `npm run lint` — ESLint
+- `npm run typecheck` — TypeScript type check
+- `npm run encrypt-key` — private key encryption tool
+
+## Production Notes
+
+- Keep secrets in env vars or a secret manager
+- Store private keys encrypted; never commit plaintext keys
+- Use a strong `JWT_SECRET` (≥ 32 chars)
+- Enable MongoDB for persistence in production
+- Review rate limits and logging retention
+
+## License
 
 ISC
+

--- a/src/__tests__/visualization/DeliberationVisualization.test.ts
+++ b/src/__tests__/visualization/DeliberationVisualization.test.ts
@@ -106,7 +106,7 @@ describe('Deliberation Visualization Integration', () => {
         ['High completeness score', 'Good consistency']
       );
 
-      expect(message.phase).toBe('judging');
+      expect(message.phase).toBe('discussion');
       expect(message.messageType).toBe('evaluation');
       expect(message.content.scores?.completeness).toBe(0.9);
       expect(message.content.reasoning).toContain('High completeness score');
@@ -123,7 +123,7 @@ describe('Deliberation Visualization Integration', () => {
         2
       );
 
-      expect(message.phase).toBe('judging');
+      expect(message.phase).toBe('discussion');
       expect(message.messageType).toBe('comparison');
       expect(message.content.winner).toBe('A');
       expect(message.content.scores?.A).toBe(0.82);

--- a/src/container.ts
+++ b/src/container.ts
@@ -28,6 +28,7 @@ import { ConsensusSynthesizer } from './infrastructure/committee/synthesizer/Con
 import { MessageCollector } from './infrastructure/committee/MessageCollector';
 import { DeliberationEventEmitter } from './infrastructure/committee/events/DeliberationEventEmitter';
 import { DeliberationVisualizationController } from './interfaces/controllers/DeliberationVisualizationController';
+import { DecisionCoordinator } from './infrastructure/coordination/DecisionCoordinator';
 
 const container = new Container();
 
@@ -37,16 +38,16 @@ container.bind<MongoDBConnection>('MongoDBConnection').to(MongoDBConnection).inS
 // Repositories - Use MongoDB in production, InMemory for testing
 const useMongoDB = process.env.USE_MONGODB === 'true';
 if (useMongoDB) {
-  container.bind<IContractRepository>('IContractRepository').to(MongoContractRepository);
-  container.bind<IOracleDecisionRepository>('IOracleDecisionRepository').to(MongoOracleDecisionRepository);
+  container.bind<IContractRepository>('IContractRepository').to(MongoContractRepository).inSingletonScope();
+  container.bind<IOracleDecisionRepository>('IOracleDecisionRepository').to(MongoOracleDecisionRepository).inSingletonScope();
 } else {
-  container.bind<IContractRepository>('IContractRepository').to(InMemoryContractRepository);
-  container.bind<IOracleDecisionRepository>('IOracleDecisionRepository').to(InMemoryOracleDecisionRepository);
+  container.bind<IContractRepository>('IContractRepository').to(InMemoryContractRepository).inSingletonScope();
+  container.bind<IOracleDecisionRepository>('IOracleDecisionRepository').to(InMemoryOracleDecisionRepository).inSingletonScope();
 }
 
 // Services
 container.bind<IAIService>('IAIService').to(OpenAIService);
-container.bind<IBlockchainService>('IBlockchainService').to(EthereumService);
+container.bind<IBlockchainService>('IBlockchainService').to(EthereumService).inSingletonScope();
 container.bind<JwtService>('JwtService').to(JwtService);
 container.bind<CryptoService>('CryptoService').to(CryptoService);
 
@@ -59,6 +60,9 @@ container.bind<ISynthesizerService>('SynthesizerService').to(ConsensusSynthesize
 container.bind<DeliberationEventEmitter>('DeliberationEventEmitter').to(DeliberationEventEmitter).inSingletonScope();
 container.bind<MessageCollector>('MessageCollector').to(MessageCollector);
 container.bind<DeliberationVisualizationController>('DeliberationVisualizationController').to(DeliberationVisualizationController);
+
+// Coordination
+container.bind<DecisionCoordinator>('DecisionCoordinator').to(DecisionCoordinator).inSingletonScope();
 
 // Proposer Agents - Always bind all agents, filtering will be done at runtime
 container.bind<IAgentService>('GPT5Proposer').to(GPT5Proposer);

--- a/src/domain/repositories/IContractRepository.ts
+++ b/src/domain/repositories/IContractRepository.ts
@@ -4,6 +4,11 @@ export interface IContractRepository {
   findById(id: string): Promise<Contract | null>;
   findByAddress(address: string): Promise<Contract | null>;
   findContractsReadyForDecision(): Promise<Contract[]>;
+  /**
+   * Contracts whose betting should be closed now based on local data
+   * (status CREATED or BETTING_OPEN) and bettingEndTime <= now.
+   */
+  findContractsToClose(): Promise<Contract[]>;
   save(contract: Contract): Promise<void>;
   update(contract: Contract): Promise<void>;
 }

--- a/src/domain/services/IBlockchainService.ts
+++ b/src/domain/services/IBlockchainService.ts
@@ -16,6 +16,15 @@ export interface ContractData {
 }
 
 export interface IBlockchainService {
+  // On-chain role helpers
+  getSignerAddress(): string;
+  getOracleAddress(): Promise<string>;
+  isAuthorizedOracle(): Promise<boolean>;
+
+  closeBetting(
+    contractId: string
+  ): Promise<string>;
+
   declareWinner(
     contractId: string,
     winner: Choice

--- a/src/domain/valueObjects/DeliberationMessage.ts
+++ b/src/domain/valueObjects/DeliberationMessage.ts
@@ -1,4 +1,4 @@
-export type DeliberationPhase = 'proposing' | 'judging' | 'consensus' | 'completed';
+export type DeliberationPhase = 'proposing' | 'discussion' | 'consensus' | 'completed';
 export type MessageType = 'proposal' | 'evaluation' | 'comparison' | 'vote' | 'synthesis' | 'progress';
 
 export interface DeliberationMessageContent {
@@ -76,7 +76,7 @@ export class DeliberationMessage {
   ): DeliberationMessage {
     return new DeliberationMessage(
       `evaluation_${proposalId}_${Date.now()}`,
-      'judging',
+      'discussion',
       'evaluation',
       {
         text: `규칙 기반 평가 완료: ${reasoning.join(', ')}`,
@@ -103,7 +103,7 @@ export class DeliberationMessage {
   ): DeliberationMessage {
     return new DeliberationMessage(
       `comparison_${proposalAId}_${proposalBId}_${round}_${Date.now()}`,
-      'judging',
+      'discussion',
       'comparison',
       {
         text: `쌍대 비교 Round ${round}: ${winner} 승리`,

--- a/src/domain/valueObjects/DeliberationVisualization.ts
+++ b/src/domain/valueObjects/DeliberationVisualization.ts
@@ -1,7 +1,7 @@
 import { DeliberationMessage } from './DeliberationMessage';
 
 export interface ProgressData {
-  currentPhase: 'proposing' | 'judging' | 'consensus' | 'completed';
+  currentPhase: 'proposing' | 'discussion' | 'consensus' | 'completed';
   completedSteps: string[];
   totalSteps: number;
   percentComplete: number;

--- a/src/domain/valueObjects/WinnerJuryArguments.ts
+++ b/src/domain/valueObjects/WinnerJuryArguments.ts
@@ -1,0 +1,15 @@
+export interface WinnerJuryArguments {
+  Jury1: string;
+  Jury2: string;
+  Jury3: string;
+  Conclusion: string;
+}
+
+export function isWinnerJuryArguments(obj: any): obj is WinnerJuryArguments {
+  return obj && typeof obj === 'object'
+    && typeof obj.Jury1 === 'string'
+    && typeof obj.Jury2 === 'string'
+    && typeof obj.Jury3 === 'string'
+    && typeof obj.Conclusion === 'string';
+}
+

--- a/src/infrastructure/ai/ClaudeJurySynthesisService.ts
+++ b/src/infrastructure/ai/ClaudeJurySynthesisService.ts
@@ -1,0 +1,148 @@
+import { Anthropic } from '@anthropic-ai/sdk';
+import { DeliberationMessage } from '../../domain/valueObjects/DeliberationMessage';
+import { WinnerJuryArguments, isWinnerJuryArguments } from '../../domain/valueObjects/WinnerJuryArguments';
+import { logger } from '../logging/Logger';
+
+export interface JurySynthesisInput {
+  winnerId: string;
+  contractId: string;
+  messages: DeliberationMessage[];
+  locale?: 'ko' | 'en';
+}
+
+export class ClaudeJurySynthesisService {
+  private claude: Anthropic | null = null;
+  private readonly model: string;
+
+  constructor() {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    this.model = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
+    if (apiKey) {
+      this.claude = new Anthropic({ apiKey });
+    } else {
+      logger.warn('ANTHROPIC_API_KEY not set. Falling back to local synthesis for jury arguments.');
+    }
+  }
+
+  async generate(input: JurySynthesisInput): Promise<WinnerJuryArguments> {
+    const { winnerId, messages, contractId } = input;
+
+    const supporting = messages
+      .filter(m => m.messageType === 'proposal' && m.content?.winner === winnerId)
+      .map(m => ({
+        agent: m.agentName || m.agentId || 'unknown',
+        rationale: (m.content.text || '').trim(),
+        evidence: (m.content.evidence || []).map(e => (e || '').trim()).filter(Boolean)
+      }))
+      .filter(item => item.rationale.length > 0 || item.evidence.length > 0);
+
+    if (supporting.length === 0) {
+      const proposals = messages.filter(m => m.messageType === 'proposal');
+      proposals.slice(0, 3).forEach(p => {
+        supporting.push({
+          agent: p.agentName || p.agentId || 'unknown',
+          rationale: (p.content.text || '').trim(),
+          evidence: (p.content.evidence || []).map(e => (e || '').trim()).filter(Boolean)
+        });
+      });
+    }
+
+    const limit = (s: string, n = 500) => (s.length > n ? s.slice(0, n) + '…' : s);
+    const capped = supporting.slice(0, 12).map(s => ({
+      agent: limit(s.agent, 80),
+      rationale: limit(s.rationale, 600),
+      evidence: s.evidence.slice(0, 4).map(e => limit(e, 300))
+    }));
+
+    const langCode = input.locale || 'en';
+    const language = langCode === 'ko' ? 'Korean' : 'English';
+    const header = `You are a careful logician. Build three distinct logical arguments that support the chosen winner using the provided evidence. Then derive a concise conclusion that follows inevitably from those arguments. Output strict JSON only.`;
+    const instructions = `
+Task:
+- Winner: ${winnerId}
+- Use only the provided rationales/evidence as sources; avoid assumptions.
+- Each of Jury1/2/3 should be a single, self-contained argument supported by one or more evidence pieces.
+- Conclusion must logically follow from Jury1–Jury3 without introducing new facts.
+- Output language: ${language}
+- Output format: a single compact JSON object with keys "Jury1", "Jury2", "Jury3", "Conclusion". No markdown, no code fences, no commentary.
+
+Available supporting items:
+${capped.map((s, i) => `#${i + 1} Agent=${s.agent}\nRationale=${s.rationale}\nEvidence=${s.evidence.join(' | ')}`).join('\n\n')}
+`;
+
+    if (this.claude) {
+      try {
+        const resp = await this.claude.messages.create({
+          model: this.model,
+          max_tokens: 6000,
+          temperature: 0.2,
+          system: header,
+          messages: [ { role: 'user', content: instructions } ]
+        });
+
+        const first = resp.content?.[0];
+        const text = first && (first.type === 'text') ? first.text : '';
+        const parsed = this.safeParseJSON(text);
+        if (isWinnerJuryArguments(parsed)) {
+          logger.info('Claude jury synthesis success', { contractId, winnerId, model: this.model });
+          return parsed;
+        }
+
+        logger.warn('Claude jury synthesis returned unrecognized JSON, using fallback parse', { contractId });
+        return this.fallbackFromEvidence(capped, winnerId, input.locale);
+      } catch (error) {
+        logger.error('Claude jury synthesis failed, using local fallback', {
+          contractId,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        });
+        return this.fallbackFromEvidence(capped, winnerId, input.locale);
+      }
+    }
+
+    return this.fallbackFromEvidence(capped, winnerId, input.locale);
+  }
+
+  private safeParseJSON(raw: string): any {
+    if (!raw) return null;
+    let s = raw.trim();
+    if (s.startsWith('```')) {
+      s = s.replace(/^```[a-zA-Z]*\n?/, '').replace(/```$/, '').trim();
+    }
+    try { return JSON.parse(s); } catch {}
+    const first = s.indexOf('{');
+    const last = s.lastIndexOf('}');
+    if (first !== -1 && last !== -1 && last > first) {
+      const inner = s.slice(first, last + 1);
+      try { return JSON.parse(inner); } catch {}
+    }
+    return null;
+  }
+
+  private fallbackFromEvidence(
+    items: Array<{ agent: string; rationale: string; evidence: string[] }>,
+    winnerId: string,
+    locale: 'ko' | 'en' = 'en'
+  ): WinnerJuryArguments {
+    const text = (s: string) => s.replace(/\s+/g, ' ').trim();
+    const arg = (i: number) => {
+      const it = items[i % items.length];
+      const ev = it?.evidence?.[0] || it?.rationale || '';
+      return locale === 'en'
+        ? `Argument ${i + 1}: ${text(it?.rationale || 'Supportive rationale')} (evidence: ${text(ev)})`
+        : `주장 ${i + 1}: ${text(it?.rationale || '지지 논거')} (근거: ${text(ev)})`;
+    };
+    const concl = () => {
+      const base = locale === 'en'
+        ? `Given the above arguments and evidence, the winner '${winnerId}' is best supported.`
+        : `위의 주장과 근거에 비추어 볼 때, 승자 '${winnerId}'가 가장 타당합니다.`;
+      return base;
+    };
+    return {
+      Jury1: arg(0),
+      Jury2: arg(1),
+      Jury3: arg(2),
+      Conclusion: concl()
+    };
+  }
+}
+

--- a/src/infrastructure/committee/MessageCollector.ts
+++ b/src/infrastructure/committee/MessageCollector.ts
@@ -65,19 +65,19 @@ export class MessageCollector {
   /**
    * Starts a new phase
    */
-  startPhase(phase: 'proposing' | 'judging' | 'consensus'): void {
+  startPhase(phase: 'proposing' | 'discussion' | 'consensus'): void {
     this.phaseStartTimes[phase] = new Date();
     
     const phaseNames = {
       proposing: '제안 생성 단계',
-      judging: '심사 단계',
+      discussion: '토의 단계',
       consensus: '합의 단계'
-    };
+    } as const;
     
     const message = DeliberationMessage.createProgress(
       phase, 
       `${phaseNames[phase]} 시작`, 
-      phase === 'proposing' ? 10 : phase === 'judging' ? 40 : 80
+      phase === 'proposing' ? 10 : phase === 'discussion' ? 40 : 80
     );
     this.addMessage(message);
   }
@@ -231,8 +231,8 @@ export class MessageCollector {
       .map((item, index) => ({ ...item, rank: index + 1 }));
     
     const message = DeliberationMessage.createProgress(
-      'judging', 
-      `심사 완료 (총 ${evaluations.length}개 평가)`, 
+      'discussion', 
+      `토의 완료 (총 ${evaluations.length}개 평가)`, 
       70
     );
     this.addMessage(message);
@@ -423,7 +423,7 @@ export class MessageCollector {
   }
 
   private buildProgressData(): ProgressData {
-    const phases = ['proposing', 'judging', 'consensus', 'completed'];
+    const phases = ['proposing', 'discussion', 'consensus', 'completed'];
     const completedSteps = this.messages
       .filter(m => m.messageType === 'progress')
       .map(m => m.content.progress?.step || '');
@@ -526,7 +526,7 @@ export class MessageCollector {
     }));
 
     const phaseBreakdown: Record<string, number> = {};
-    const phases = ['proposing', 'judging', 'consensus'];
+    const phases = ['proposing', 'discussion', 'consensus'];
     
     phases.forEach(phase => {
       const phaseMessages = this.messages.filter(m => m.phase === phase);

--- a/src/infrastructure/coordination/DecisionCoordinator.ts
+++ b/src/infrastructure/coordination/DecisionCoordinator.ts
@@ -1,0 +1,49 @@
+import { injectable } from 'inversify';
+import { logger } from '../logging/Logger';
+
+@injectable()
+export class DecisionCoordinator {
+  private inFlight: Set<string> = new Set();
+  private cooldownUntil: Map<string, number> = new Map();
+  private readonly defaultCooldownMs: number = 15000; // 15s default
+
+  /**
+   * Attempt to start work for a contract. Returns true if started, false if blocked
+   * by an in-flight job or cooldown window.
+   */
+  tryStart(contractId: string): boolean {
+    const now = Date.now();
+    const cd = this.cooldownUntil.get(contractId) || 0;
+    if (now < cd) {
+      logger.debug('DecisionCoordinator: cooldown active, skipping', { contractId, msRemaining: cd - now });
+      return false;
+    }
+    if (this.inFlight.has(contractId)) {
+      logger.debug('DecisionCoordinator: in-flight job exists, skipping', { contractId });
+      return false;
+    }
+    this.inFlight.add(contractId);
+    return true;
+  }
+
+  /**
+   * Mark work finished and start a cooldown window (defaults to 15s).
+   */
+  finish(contractId: string, cooldownMs?: number): void {
+    this.inFlight.delete(contractId);
+    const until = Date.now() + (cooldownMs ?? this.defaultCooldownMs);
+    this.cooldownUntil.set(contractId, until);
+  }
+
+  /**
+   * Explicitly set a cooldown (e.g., on hard errors) without marking in-flight.
+   */
+  setCooldown(contractId: string, cooldownMs: number): void {
+    const until = Date.now() + cooldownMs;
+    this.cooldownUntil.set(contractId, until);
+  }
+
+  isInFlight(contractId: string): boolean {
+    return this.inFlight.has(contractId);
+  }
+}

--- a/src/infrastructure/repositories/InMemoryContractRepository.ts
+++ b/src/infrastructure/repositories/InMemoryContractRepository.ts
@@ -94,6 +94,20 @@ export class InMemoryContractRepository implements IContractRepository {
     return readyContracts;
   }
 
+  async findContractsToClose(): Promise<Contract[]> {
+    const now = new Date();
+    const toClose: Contract[] = [];
+    for (const contract of this.contracts.values()) {
+      const status = contract.status;
+      if ((status === ContractStatus.CREATED || status === ContractStatus.BETTING_OPEN) &&
+          now >= contract.bettingEndTime &&
+          !contract.winnerId) {
+        toClose.push(contract);
+      }
+    }
+    return toClose;
+  }
+
   async save(contract: Contract): Promise<void> {
     this.contracts.set(contract.id, contract);
   }

--- a/src/infrastructure/repositories/MongoContractRepository.ts
+++ b/src/infrastructure/repositories/MongoContractRepository.ts
@@ -77,6 +77,16 @@ export class MongoContractRepository implements IContractRepository {
     return docs.map(doc => this.documentToEntity(doc));
   }
 
+  async findContractsToClose(): Promise<Contract[]> {
+    const now = new Date();
+    const docs = await this.collection.find({
+      status: { $in: [ContractStatus.CREATED, ContractStatus.BETTING_OPEN] },
+      bettingEndTime: { $lte: now },
+      winnerId: { $exists: false }
+    }).toArray();
+    return docs.map(doc => this.documentToEntity(doc));
+  }
+
   async save(contract: Contract): Promise<void> {
     const doc = this.entityToDocument(contract);
     await this.collection.insertOne(doc);

--- a/src/interfaces/controllers/OracleController.ts
+++ b/src/interfaces/controllers/OracleController.ts
@@ -2,9 +2,19 @@ import { Request, Response } from 'express';
 import { injectable } from 'inversify';
 import { container } from '../../container';
 import { DecideWinnerUseCase } from '../../application/useCases/DecideWinnerUseCase';
+import { IBlockchainService } from '../../domain/services/IBlockchainService';
+import { IContractRepository } from '../../domain/repositories/IContractRepository';
+import { Contract, ContractStatus } from '../../domain/entities/Contract';
+import { Party } from '../../domain/entities/Party';
+import { IOracleDecisionRepository } from '../../domain/repositories/IOracleDecisionRepository';
+import { DecisionCoordinator } from '../../infrastructure/coordination/DecisionCoordinator';
+import { DeliberationEventEmitter } from '../../infrastructure/committee/events/DeliberationEventEmitter';
+import { logger } from '../../infrastructure/logging/Logger';
 
 @injectable()
 export class OracleController {
+  // In-memory idempotency guard keyed by contractId:bettingEndTime
+  private static processedEndNotifications: Set<string> = new Set();
   async decideWinner(req: Request, res: Response): Promise<void> {
     try {
       const { contractId } = req.params;
@@ -26,6 +36,7 @@ export class OracleController {
       });
 
       if (result.success) {
+        // Original response shape
         res.status(200).json({
           success: true,
           data: {
@@ -121,6 +132,219 @@ export class OracleController {
         success: false,
         error: 'Internal server error'
       });
+    }
+  }
+
+  /**
+   * POST /api/oracle/contracts/:contractId/ended
+   * Public endpoint called by frontend when countdown reaches zero.
+   * Idempotently closes betting on-chain (status 0 -> 1) and syncs local status.
+   */
+  async markEnded(req: Request, res: Response): Promise<void> {
+    try {
+      const pathId = req.params.contractId; // numeric string expected
+      const { contractId, endedAt, bettingEndTime, chainId } = req.body || {};
+
+      // Cross-validate ids
+      if (!pathId || String(contractId) !== String(pathId)) {
+        res.status(400).json({ success: false, error: 'contractId in path and body must match' });
+        return;
+      }
+
+      const key = `${pathId}:${bettingEndTime}`;
+      if (OracleController.processedEndNotifications.has(key)) {
+        res.status(200).json({ success: true, data: { contractId: pathId, idempotent: true, action: 'already_processed' } });
+        return;
+      }
+
+      const blockchain = container.get<IBlockchainService>('IBlockchainService');
+      const contracts = container.get<IContractRepository>('IContractRepository');
+      const coordinator = container.get<DecisionCoordinator>('DecisionCoordinator');
+
+      let onchainStatus: number | null = null;
+      let onchainEnd: number | null = null;
+      let onchainData: any | null = null;
+      try {
+        onchainData = await blockchain.getContract(String(pathId));
+        onchainStatus = onchainData.status;
+        onchainEnd = onchainData.bettingEndTime;
+      } catch (e) {
+        logger.warn('markEnded: failed to read on-chain contract, proceeding best-effort', { contractId: pathId });
+      }
+
+      // Optional sanity: ensure provided bettingEndTime matches chain if available
+      if (onchainEnd && bettingEndTime && Number(onchainEnd) !== Number(bettingEndTime)) {
+        logger.warn('markEnded: bettingEndTime mismatch (body vs chain)', {
+          contractId: pathId,
+          body: Number(bettingEndTime),
+          chain: Number(onchainEnd)
+        });
+      }
+
+      let txHash: string | undefined;
+      try {
+        if (onchainStatus === null || onchainStatus === 0) {
+          logger.info('Closing betting via frontend markEnded', { contractId: pathId, endedAt, bettingEndTime, chainId });
+          txHash = await blockchain.closeBetting(String(pathId));
+        } else {
+          logger.info('markEnded: on-chain already closed/not-open, skipping tx', { contractId: pathId, onchainStatus });
+        }
+      } catch (e) {
+        logger.error('markEnded: closeBetting failed', { contractId: pathId, error: e instanceof Error ? e.message : String(e) });
+      }
+
+      // Seed local repo from chain if missing, then mark closed
+      try {
+        let local = await contracts.findById(String(pathId));
+        if (!local && onchainData) {
+          // Map on-chain fields to domain entity
+          const partyA = new Party(`${pathId}:1`, '', onchainData.partyA || 'Party A', onchainData.partyA || 'Party A');
+          const partyB = new Party(`${pathId}:2`, '', onchainData.partyB || 'Party B', onchainData.partyB || 'Party B');
+          const bettingEnd = new Date((onchainData.bettingEndTime || Math.floor(Date.now()/1000)) * 1000);
+
+          // Map status: 0 Active->BETTING_OPEN, 1 Closed->BETTING_CLOSED, 2 Resolved->DECIDED, 3 Distributed->DISTRIBUTED, 4 Cancelled->BETTING_CLOSED
+          const statusMap: Record<number, ContractStatus> = {
+            0: ContractStatus.BETTING_OPEN,
+            1: ContractStatus.BETTING_CLOSED,
+            2: ContractStatus.DECIDED,
+            3: ContractStatus.DISTRIBUTED,
+            4: ContractStatus.BETTING_CLOSED
+          } as any;
+          const mappedStatus = statusMap[Number(onchainData.status)] || ContractStatus.BETTING_OPEN;
+
+          const contractAddress = process.env.MAIN_CONTRACT_ADDRESS || `0x${'0'.repeat(40)}`;
+
+          local = new Contract(
+            String(pathId),
+            contractAddress,
+            partyA,
+            partyB,
+            bettingEnd,
+            Number(onchainData.partyRewardPercentage || 0),
+            mappedStatus
+          );
+          await contracts.save(local);
+          logger.info('markEnded: seeded contract from chain', { contractId: pathId, status: mappedStatus });
+        }
+        // Fallback seeding from request body when chain read failed
+        if (!local && !onchainData) {
+          const partyA = new Party(`${pathId}:1`, '', 'Party A', 'Party A');
+          const partyB = new Party(`${pathId}:2`, '', 'Party B', 'Party B');
+          const bettingEnd = new Date((Number(bettingEndTime) || Math.floor(Date.now()/1000)) * 1000);
+          const contractAddress = process.env.MAIN_CONTRACT_ADDRESS || `0x${'0'.repeat(40)}`;
+
+          local = new Contract(
+            String(pathId),
+            contractAddress,
+            partyA,
+            partyB,
+            bettingEnd,
+            1, // default 1% per contract constant in chain
+            ContractStatus.BETTING_CLOSED
+          );
+          await contracts.save(local);
+          logger.info('markEnded: seeded contract from request body (fallback)', { contractId: pathId });
+        }
+        if (local) {
+          local.status = ContractStatus.BETTING_CLOSED;
+          await contracts.update(local);
+        }
+      } catch (e) {
+        logger.warn('markEnded: failed to seed/update local contract', { contractId: pathId, error: e instanceof Error ? e.message : String(e) });
+      }
+
+      OracleController.processedEndNotifications.add(key);
+
+      // Trigger async winner decision so oracle activation doesn't depend on prior events
+      try {
+        // Use coordinator to avoid duplicate trigger if monitor also picks it up
+        if (coordinator.tryStart(String(pathId))) {
+          const decideWinnerUseCase = container.get<DecideWinnerUseCase>('DecideWinnerUseCase');
+          const deliberationId = `committee_${pathId}_${Date.now()}`;
+          decideWinnerUseCase.executeAsync({ contractId: String(pathId), deliberationId })
+            .catch(err => {
+              logger.error('markEnded: async decision trigger failed', { contractId: pathId, error: err instanceof Error ? err.message : String(err) });
+            })
+            .finally(() => coordinator.finish(String(pathId)));
+        } else {
+          logger.debug('markEnded: decision already in progress or cooling down, skipping trigger', { contractId: pathId });
+        }
+      } catch (e) {
+        logger.warn('markEnded: could not trigger async decision', { contractId: pathId, error: e instanceof Error ? e.message : String(e) });
+      }
+
+      res.status(200).json({
+        success: true,
+        data: {
+          contractId: pathId,
+          action: onchainStatus === 0 || onchainStatus === null ? 'closed' : 'already_closed',
+          idempotent: false,
+          transactionHash: txHash
+        }
+      });
+    } catch (error) {
+      console.error('Controller error:', error);
+      res.status(500).json({ success: false, error: 'Internal server error' });
+    }
+  }
+
+  /**
+   * GET /api/oracle/contracts/:contractId/winner-arguments
+   * Public endpoint to fetch structured jury arguments (Claude-based, with fallback) for a contract.
+   */
+  async getWinnerArguments(req: Request, res: Response): Promise<void> {
+    try {
+      const { contractId } = req.params;
+      const lang = (req.query.lang as string) === 'ko' ? 'ko' : 'en';
+      const decisionRepo = container.get<IOracleDecisionRepository>('IOracleDecisionRepository');
+      const emitter = container.get<DeliberationEventEmitter>('DeliberationEventEmitter');
+
+      const decision = await decisionRepo.findByContractId(String(contractId));
+      if (!decision) {
+        res.status(404).json({ success: false, error: 'Decision not found for contract' });
+        return;
+      }
+
+      // Try to use real deliberation messages first
+      let messages = emitter.getMessageHistory(String(contractId));
+      if (!messages || messages.length === 0) {
+        // Synthesize a minimal proposal from decision metadata as seed
+        const { DeliberationMessage } = await import('../../domain/valueObjects/DeliberationMessage');
+        const md: any = decision.metadata || {};
+        const dp: any = md.dataPoints || {};
+        const all = [md.reasoning, dp.evidence].flat().filter(Boolean) as any[];
+        const flatStrings = all
+          .map(v => (typeof v === 'string' ? v : (() => { try { return JSON.stringify(v); } catch { return String(v); } })()))
+          .filter(Boolean) as string[];
+        const synthetic = DeliberationMessage.createProposal(
+          'jury_synthesizer',
+          'Jury Synthesis Seed',
+          decision.winnerId,
+          md.confidence ?? 0.85,
+          md.reasoning || 'Auto-generated rationale from decision metadata',
+          flatStrings.slice(0, 3),
+          0,
+          0
+        );
+        messages = [synthetic];
+      }
+
+      const { ClaudeJurySynthesisService } = await import('../../infrastructure/ai/ClaudeJurySynthesisService');
+      const service = new ClaudeJurySynthesisService();
+      const data = await service.generate({
+        winnerId: decision.winnerId,
+        contractId: String(contractId),
+        messages,
+        locale: lang as any
+      });
+
+      res.status(200).json({ success: true, data });
+    } catch (error) {
+      logger.error('Failed to get winner arguments', {
+        contractId: req.params.contractId,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+      res.status(500).json({ success: false, error: 'Internal server error' });
     }
   }
 }

--- a/src/interfaces/routes/deliberationRoutes.ts
+++ b/src/interfaces/routes/deliberationRoutes.ts
@@ -68,6 +68,22 @@ router.get(
 );
 
 /**
+ * GET /api/deliberations/:id/winner-arguments
+ * Returns three logical arguments (with evidence) and a conclusion supporting the winner
+ */
+router.get(
+  '/:id/winner-arguments',
+  authenticate,
+  authorize('ADMIN', 'ORACLE_NODE'),
+  apiRateLimiter,
+  validate(getDeliberationSchema),
+  asyncHandler(async (req, res) => {
+    const controller = getController();
+    await controller.getWinnerJuryArguments(req, res);
+  })
+);
+
+/**
  * GET /api/deliberations/:id/export
  * Exports deliberation data as a comprehensive report
  * Supports JSON and CSV formats

--- a/src/interfaces/routes/oracleRoutes.ts
+++ b/src/interfaces/routes/oracleRoutes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { OracleController } from '../controllers/OracleController';
 import { authenticate, authorize } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validationMiddleware';
-import { decideWinnerValidationSchema, getDecisionValidationSchema } from '../validation/schemas';
+import { decideWinnerValidationSchema, getDecisionValidationSchema, endedNotificationSchema, getWinnerArgumentsSchema } from '../validation/schemas';
 import { oracleRateLimiter } from '../middleware/rateLimitMiddleware';
 import { asyncHandler } from '../middleware/errorMiddleware';
 import { UserRole } from '../../domain/entities/User';
@@ -31,6 +31,20 @@ export function createOracleRoutes(): Router {
     authenticate(),
     validate(getDecisionValidationSchema),
     asyncHandler((req, res) => controller.getDecision(req, res))
+  );
+
+  // Public: fetch winner arguments/reasoning for a contract
+  router.get('/contracts/:contractId/winner-arguments',
+    oracleRateLimiter,
+    validate(getWinnerArgumentsSchema),
+    asyncHandler((req, res) => controller.getWinnerArguments(req, res))
+  );
+
+  // Public endpoint: Frontend notifies when countdown ended (idempotent close)
+  router.post('/contracts/:contractId/ended',
+    oracleRateLimiter,
+    validate(endedNotificationSchema),
+    asyncHandler((req, res) => controller.markEnded(req, res))
   );
 
   return router;

--- a/src/interfaces/validation/schemas.ts
+++ b/src/interfaces/validation/schemas.ts
@@ -105,10 +105,10 @@ export const deliberationQuerySchema = Joi.object({
       'number.max': 'Limit cannot exceed 200'
     }),
   phase: Joi.string()
-    .valid('proposing', 'judging', 'consensus', 'completed')
+    .valid('proposing', 'discussion', 'consensus', 'completed')
     .optional()
     .messages({
-      'any.only': 'Phase must be one of: proposing, judging, consensus, completed'
+      'any.only': 'Phase must be one of: proposing, discussion, consensus, completed'
     }),
   agentId: Joi.string()
     .pattern(/^[a-zA-Z0-9_-]+$/)
@@ -159,4 +159,37 @@ export const getDeliberationMessagesSchema = Joi.object({
 
 export const exportDeliberationSchema = Joi.object({
   params: deliberationParamsSchema
+});
+
+// Frontend-ended notification schema
+export const endedNotificationSchema = Joi.object({
+  params: Joi.object({
+    contractId: Joi.string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'string.pattern.base': 'Contract ID in path must be a numeric string'
+      })
+  }),
+  body: Joi.object({
+    contractId: Joi.number().integer().required(),
+    endedAt: Joi.string().isoDate().required(),
+    bettingEndTime: Joi.number().integer().required(), // seconds
+    chainId: Joi.number().integer().required()
+  })
+});
+
+// Winner arguments fetch schema (public)
+export const getWinnerArgumentsSchema = Joi.object({
+  params: Joi.object({
+    contractId: Joi.string()
+      .pattern(/^\d+$/)
+      .required()
+      .messages({
+        'string.pattern.base': 'Contract ID in path must be a numeric string'
+      })
+  }),
+  query: Joi.object({
+    lang: Joi.string().valid('ko', 'en').optional()
+  }).optional()
 });


### PR DESCRIPTION
…y-first; update phases to 'discussion'; add winner-arguments; fix CommitteeDecision winner validation; add .env.example; update docs to English

- Orchestrator: multi-round discussion with peer-aware stance updates; per-round voting; unanimity or majority fallback; use latest proposals for decision/evidence
- Message/Visualization: phases use 'discussion' instead of 'judging'
- Validation: schemas accept phase=discussion
- Winner arguments: add Claude-based synthesis with fallback; public endpoint docs
- Fix: ensure final winner is among proposals by using updated anchors
- README: English rewrite reflecting new flow and env toggles (UNANIMOUS_MAX_ROUNDS, DISCUSSION_ROUNDS)
- Add: .env.example with commented placeholders
- Tests: adjust expectations for 'discussion' phase